### PR TITLE
Change terraform version and remove deprecated code

### DIFF
--- a/ez_vpc_cluster/dynamic_acl_allow_rules/versions.tf
+++ b/ez_vpc_cluster/dynamic_acl_allow_rules/versions.tf
@@ -5,8 +5,7 @@
 terraform {
   required_providers {
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3"
 }
 
 ##############################################################################

--- a/ez_vpc_cluster/versions.tf
+++ b/ez_vpc_cluster/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~>1.38.2"
     }
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3"
 }
 
 ##############################################################################

--- a/ez_vpc_cluster/vpc/versions.tf
+++ b/ez_vpc_cluster/vpc/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~>1.38.2"
     }
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3"
 }
 
 ##############################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "region" {
 variable "resource_group" {
   description = "Name of existing resource group where all infrastructure will be provisioned"
   type        = string
-  default     = "asset-development"
+  default     = "default"
 
   validation {
     error_message = "Unique ID must begin and end with a letter and contain only letters, numbers, and - characters."

--- a/versions.tf
+++ b/versions.tf
@@ -9,8 +9,7 @@ terraform {
       version = "~>1.38.2"
     }
   }
-  required_version = ">=1.0"
-  experiments      = [module_variable_optional_attrs]
+  required_version = ">=1.3"
 }
 
 ##############################################################################


### PR DESCRIPTION
When I attempted to use this terraform code, it failed for a couple of reasons:

1. This: `experiments = [module_variable_optional_attrs]` is no longer supported in tf versions 1.3 and later. See https://github.com/hashicorp/terraform/issues/31692 for more details

So I removed that line and bumped the required tf version to 1.3

2. The provided resource group also fails. I changed that to `default`. With the default resource group, the code will provision as written with no changes needed. The user can always change the resource group name if they want - which they would have to do anyway once they hit an error on `"asset-development"`

There are a couple of other changes I'd recommend: such as, turning on the public service endpoint (otherwise the user can't interact with the cluster w/o a jumpbox) and changing `variable "wait_till"` to `OneWorkerNodeReady` to prevent tf from hanging if ingress takes a long time to complete. But I can open a new PR for those types of changes.